### PR TITLE
Closes #39 Cleanup: Revert local configuration overrides in the source index

### DIFF
--- a/__ideas8/AbsMinSpec.scala
+++ b/__ideas8/AbsMinSpec.scala
@@ -1,0 +1,15 @@
+package Mathematics
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class AbsMinSpec extends AnyFlatSpec {
+
+  "abs min spec 1" should "output the correct Integer as a result from the list of elements" in {
+    assert(AbsMin.absMin(List(1000, -1, 999, 72, 65, -56, -767)) === 1)
+  }
+
+  "abs min spec 2" should "output the correct Integer as a result from the list of elements" in {
+    assert(AbsMin.absMin(List(121, 221, 3, 4112)) === 3)
+  }
+
+}

--- a/__ideas8/CelebrityFinderTest.java
+++ b/__ideas8/CelebrityFinderTest.java
@@ -1,0 +1,41 @@
+package com.thealgorithms.stacks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CelebrityFinderTest {
+
+    @ParameterizedTest
+    @MethodSource("providePartyMatrices")
+    public void testCelebrityFinder(int[][] party, int expected) {
+        assertEquals(expected, CelebrityFinder.findCelebrity(party));
+    }
+
+    private static Stream<Arguments> providePartyMatrices() {
+        return Stream.of(
+            // Test case 1: Celebrity exists
+            Arguments.of(new int[][] {{0, 1, 1}, {0, 0, 1}, {0, 0, 0}}, 2),
+
+            // Test case 2: No celebrity
+            Arguments.of(new int[][] {{0, 1, 0}, {1, 0, 1}, {1, 1, 0}}, -1),
+
+            // Test case 3: Everyone knows each other, no celebrity
+            Arguments.of(new int[][] {{0, 1, 1}, {1, 0, 1}, {1, 1, 0}}, -1),
+
+            // Test case 4: Single person, they are trivially a celebrity
+            Arguments.of(new int[][] {{0}}, 0),
+
+            // Test case 5: All know the last person, and they know no one
+            Arguments.of(new int[][] {{0, 1, 1, 1}, {0, 0, 1, 1}, {0, 0, 0, 1}, {0, 0, 0, 0}}, 3),
+
+            // Test case 6: Larger party with no celebrity
+            Arguments.of(new int[][] {{0, 1, 1, 0}, {1, 0, 0, 1}, {0, 1, 0, 1}, {1, 1, 1, 0}}, -1),
+
+            // Test case 7: Celebrity at the start of the matrix
+            Arguments.of(new int[][] {{0, 0, 0}, {1, 0, 1}, {1, 1, 0}}, 0));
+    }
+}

--- a/__ideas8/FibonacciLoop.java
+++ b/__ideas8/FibonacciLoop.java
@@ -1,0 +1,41 @@
+package com.thealgorithms.maths;
+
+import java.math.BigInteger;
+
+/**
+ * This class provides methods for calculating Fibonacci numbers using BigInteger for large values of 'n'.
+ */
+public final class FibonacciLoop {
+
+    private FibonacciLoop() {
+        // Private constructor to prevent instantiation of this utility class.
+    }
+
+    /**
+     * Calculates the nth Fibonacci number.
+     *
+     * @param n The index of the Fibonacci number to calculate.
+     * @return The nth Fibonacci number as a BigInteger.
+     * @throws IllegalArgumentException if the input 'n' is a negative integer.
+     */
+    public static BigInteger compute(final int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("Input 'n' must be a non-negative integer.");
+        }
+
+        if (n <= 1) {
+            return BigInteger.valueOf(n);
+        }
+
+        BigInteger prev = BigInteger.ZERO;
+        BigInteger current = BigInteger.ONE;
+
+        for (int i = 2; i <= n; i++) {
+            BigInteger next = prev.add(current);
+            prev = current;
+            current = next;
+        }
+
+        return current;
+    }
+}

--- a/__ideas8/GenerateParentheses.test.js
+++ b/__ideas8/GenerateParentheses.test.js
@@ -1,0 +1,11 @@
+import { generateParentheses } from '../generateParentheses'
+
+test('generate all valid parentheses of input 3', () => {
+  expect(generateParentheses(3)).toStrictEqual([
+    '((()))',
+    '(()())',
+    '(())()',
+    '()(())',
+    '()()()'
+  ])
+})

--- a/__ideas8/LevenshteinDistance.js
+++ b/__ideas8/LevenshteinDistance.js
@@ -1,0 +1,43 @@
+/* The Levenshtein distance (a.k.a edit distance) is a
+measure of similarity between two strings. It is
+defined as the minimum number of changes required to
+convert string a into string b (this is done by
+inserting, deleting or replacing a character in
+string a).
+The smaller the Levenshtein distance,
+the more similar the strings are. This is a very
+common problem in the application of Dynamic Programming.
+*/
+
+const levenshteinDistance = (a, b) => {
+  // Declaring array 'D' with rows = len(a) + 1 and columns = len(b) + 1:
+  const distanceMatrix = Array(b.length + 1)
+    .fill(null)
+    .map(() => Array(a.length + 1).fill(null))
+
+  // Initializing first column:
+  for (let i = 0; i <= a.length; i += 1) {
+    distanceMatrix[0][i] = i
+  }
+
+  // Initializing first row:
+  for (let j = 0; j <= b.length; j += 1) {
+    distanceMatrix[j][0] = j
+  }
+
+  for (let j = 1; j <= b.length; j += 1) {
+    for (let i = 1; i <= a.length; i += 1) {
+      const indicator = a[i - 1] === b[j - 1] ? 0 : 1
+      // choosing the minimum of all three, vis-a-vis:
+      distanceMatrix[j][i] = Math.min(
+        distanceMatrix[j][i - 1] + 1, // deletion
+        distanceMatrix[j - 1][i] + 1, // insertion
+        distanceMatrix[j - 1][i - 1] + indicator // substitution
+      )
+    }
+  }
+
+  return distanceMatrix[b.length][a.length]
+}
+
+export { levenshteinDistance }

--- a/__ideas8/StatAlgo.jl
+++ b/__ideas8/StatAlgo.jl
@@ -1,0 +1,17 @@
+export StatAlgo
+"""
+  StatAlgo
+
+`StatAlgo` in Julia
+"""
+module StatAlgo
+
+using TheAlgorithms
+
+export pearson_correlation
+export variance
+
+include("pearson_correlation.jl")
+include("variance.jl")
+
+end

--- a/__ideas8/dijkstra.rs
+++ b/__ideas8/dijkstra.rs
@@ -1,0 +1,159 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Add;
+
+type Graph<V, E> = BTreeMap<V, BTreeMap<V, E>>;
+
+// performs Dijsktra's algorithm on the given graph from the given start
+// the graph is a positively-weighted directed graph
+//
+// returns a map that for each reachable vertex associates the distance and the predecessor
+// since the start has no predecessor but is reachable, map[start] will be None
+//
+// Time: O(E * logV). For each vertex, we traverse each edge, resulting in O(E). For each edge, we
+// insert a new shortest path for a vertex into the tree, resulting in O(E * logV).
+// Space: O(V). The tree holds up to V vertices.
+pub fn dijkstra<V: Ord + Copy, E: Ord + Copy + Add<Output = E>>(
+    graph: &Graph<V, E>,
+    start: V,
+) -> BTreeMap<V, Option<(V, E)>> {
+    let mut ans = BTreeMap::new();
+    let mut prio = BTreeSet::new();
+
+    // start is the special case that doesn't have a predecessor
+    ans.insert(start, None);
+
+    for (new, weight) in &graph[&start] {
+        ans.insert(*new, Some((start, *weight)));
+        prio.insert((*weight, *new));
+    }
+
+    while let Some((path_weight, vertex)) = prio.pop_first() {
+        for (next, weight) in &graph[&vertex] {
+            let new_weight = path_weight + *weight;
+            match ans.get(next) {
+                // if ans[next] is a lower dist than the alternative one, we do nothing
+                Some(Some((_, dist_next))) if new_weight >= *dist_next => {}
+                // if ans[next] is None then next is start and so the distance won't be changed, it won't be added again in prio
+                Some(None) => {}
+                // the new path is shorter, either new was not in ans or it was farther
+                _ => {
+                    if let Some(Some((_, prev_weight))) =
+                        ans.insert(*next, Some((vertex, new_weight)))
+                    {
+                        prio.remove(&(prev_weight, *next));
+                    }
+                    prio.insert((new_weight, *next));
+                }
+            }
+        }
+    }
+
+    ans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{dijkstra, Graph};
+    use std::collections::BTreeMap;
+
+    fn add_edge<V: Ord + Copy, E: Ord>(graph: &mut Graph<V, E>, v1: V, v2: V, c: E) {
+        graph.entry(v1).or_default().insert(v2, c);
+        graph.entry(v2).or_default();
+    }
+
+    #[test]
+    fn single_vertex() {
+        let mut graph: Graph<usize, usize> = BTreeMap::new();
+        graph.insert(0, BTreeMap::new());
+
+        let mut dists = BTreeMap::new();
+        dists.insert(0, None);
+
+        assert_eq!(dijkstra(&graph, 0), dists);
+    }
+
+    #[test]
+    fn single_edge() {
+        let mut graph = BTreeMap::new();
+        add_edge(&mut graph, 0, 1, 2);
+
+        let mut dists_0 = BTreeMap::new();
+        dists_0.insert(0, None);
+        dists_0.insert(1, Some((0, 2)));
+
+        assert_eq!(dijkstra(&graph, 0), dists_0);
+
+        let mut dists_1 = BTreeMap::new();
+        dists_1.insert(1, None);
+
+        assert_eq!(dijkstra(&graph, 1), dists_1);
+    }
+
+    #[test]
+    fn tree_1() {
+        let mut graph = BTreeMap::new();
+        let mut dists = BTreeMap::new();
+        dists.insert(1, None);
+        for i in 1..100 {
+            add_edge(&mut graph, i, i * 2, i * 2);
+            add_edge(&mut graph, i, i * 2 + 1, i * 2 + 1);
+
+            match dists[&i] {
+                Some((_, d)) => {
+                    dists.insert(i * 2, Some((i, d + i * 2)));
+                    dists.insert(i * 2 + 1, Some((i, d + i * 2 + 1)));
+                }
+                None => {
+                    dists.insert(i * 2, Some((i, i * 2)));
+                    dists.insert(i * 2 + 1, Some((i, i * 2 + 1)));
+                }
+            }
+        }
+
+        assert_eq!(dijkstra(&graph, 1), dists);
+    }
+
+    #[test]
+    fn graph_1() {
+        let mut graph = BTreeMap::new();
+        add_edge(&mut graph, 'a', 'c', 12);
+        add_edge(&mut graph, 'a', 'd', 60);
+        add_edge(&mut graph, 'b', 'a', 10);
+        add_edge(&mut graph, 'c', 'b', 20);
+        add_edge(&mut graph, 'c', 'd', 32);
+        add_edge(&mut graph, 'e', 'a', 7);
+
+        let mut dists_a = BTreeMap::new();
+        dists_a.insert('a', None);
+        dists_a.insert('c', Some(('a', 12)));
+        dists_a.insert('d', Some(('c', 44)));
+        dists_a.insert('b', Some(('c', 32)));
+        assert_eq!(dijkstra(&graph, 'a'), dists_a);
+
+        let mut dists_b = BTreeMap::new();
+        dists_b.insert('b', None);
+        dists_b.insert('a', Some(('b', 10)));
+        dists_b.insert('c', Some(('a', 22)));
+        dists_b.insert('d', Some(('c', 54)));
+        assert_eq!(dijkstra(&graph, 'b'), dists_b);
+
+        let mut dists_c = BTreeMap::new();
+        dists_c.insert('c', None);
+        dists_c.insert('b', Some(('c', 20)));
+        dists_c.insert('d', Some(('c', 32)));
+        dists_c.insert('a', Some(('b', 30)));
+        assert_eq!(dijkstra(&graph, 'c'), dists_c);
+
+        let mut dists_d = BTreeMap::new();
+        dists_d.insert('d', None);
+        assert_eq!(dijkstra(&graph, 'd'), dists_d);
+
+        let mut dists_e = BTreeMap::new();
+        dists_e.insert('e', None);
+        dists_e.insert('a', Some(('e', 7)));
+        dists_e.insert('c', Some(('a', 19)));
+        dists_e.insert('d', Some(('c', 51)));
+        dists_e.insert('b', Some(('c', 39)));
+        assert_eq!(dijkstra(&graph, 'e'), dists_e);
+    }
+}

--- a/__ideas8/ordinary_least_squares_regressor.cpp
+++ b/__ideas8/ordinary_least_squares_regressor.cpp
@@ -1,0 +1,473 @@
+/**
+ * @file
+ * \brief Linear regression example using [Ordinary least
+ * squares](https://en.wikipedia.org/wiki/Ordinary_least_squares)
+ *
+ * Program that gets the number of data samples and number of features per
+ * sample along with output per sample. It applies OLS regression to compute
+ * the regression output for additional test data samples.
+ *
+ * \author [Krishna Vedala](https://github.com/kvedala)
+ */
+#include <cassert>
+#include <cmath>    // for std::abs
+#include <iomanip>  // for print formatting
+#include <iostream>
+#include <vector>
+
+/**
+ * operator to print a matrix
+ */
+template <typename T>
+std::ostream &operator<<(std::ostream &out,
+                         std::vector<std::vector<T>> const &v) {
+    const int width = 10;
+    const char separator = ' ';
+
+    for (size_t row = 0; row < v.size(); row++) {
+        for (size_t col = 0; col < v[row].size(); col++) {
+            out << std::left << std::setw(width) << std::setfill(separator)
+                << v[row][col];
+        }
+        out << std::endl;
+    }
+
+    return out;
+}
+
+/**
+ * operator to print a vector
+ */
+template <typename T>
+std::ostream &operator<<(std::ostream &out, std::vector<T> const &v) {
+    const int width = 15;
+    const char separator = ' ';
+
+    for (size_t row = 0; row < v.size(); row++) {
+        out << std::left << std::setw(width) << std::setfill(separator)
+            << v[row];
+    }
+
+    return out;
+}
+
+/**
+ * function to check if given matrix is a square matrix
+ * \returns 1 if true, 0 if false
+ */
+template <typename T>
+inline bool is_square(std::vector<std::vector<T>> const &A) {
+    // Assuming A is square matrix
+    size_t N = A.size();
+    for (size_t i = 0; i < N; i++) {
+        if (A[i].size() != N) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Matrix multiplication such that if A is size (mxn) and
+ * B is of size (pxq) then the multiplication is defined
+ * only when n = p and the resultant matrix is of size (mxq)
+ *
+ * \returns resultant matrix
+ **/
+template <typename T>
+std::vector<std::vector<T>> operator*(std::vector<std::vector<T>> const &A,
+                                      std::vector<std::vector<T>> const &B) {
+    // Number of rows in A
+    size_t N_A = A.size();
+    // Number of columns in B
+    size_t N_B = B[0].size();
+
+    std::vector<std::vector<T>> result(N_A);
+
+    if (A[0].size() != B.size()) {
+        std::cerr << "Number of columns in A != Number of rows in B ("
+                  << A[0].size() << ", " << B.size() << ")" << std::endl;
+        return result;
+    }
+
+    for (size_t row = 0; row < N_A; row++) {
+        std::vector<T> v(N_B);
+        for (size_t col = 0; col < N_B; col++) {
+            v[col] = static_cast<T>(0);
+            for (size_t j = 0; j < B.size(); j++) {
+                v[col] += A[row][j] * B[j][col];
+            }
+        }
+        result[row] = v;
+    }
+
+    return result;
+}
+
+/**
+ * multiplication of a matrix with a column vector
+ * \returns resultant vector
+ */
+template <typename T>
+std::vector<T> operator*(std::vector<std::vector<T>> const &A,
+                         std::vector<T> const &B) {
+    // Number of rows in A
+    size_t N_A = A.size();
+
+    std::vector<T> result(N_A);
+
+    if (A[0].size() != B.size()) {
+        std::cerr << "Number of columns in A != Number of rows in B ("
+                  << A[0].size() << ", " << B.size() << ")" << std::endl;
+        return result;
+    }
+
+    for (size_t row = 0; row < N_A; row++) {
+        result[row] = static_cast<T>(0);
+        for (size_t j = 0; j < B.size(); j++) result[row] += A[row][j] * B[j];
+    }
+
+    return result;
+}
+
+/**
+ * pre-multiplication of a vector by a scalar
+ * \returns resultant vector
+ */
+template <typename T>
+std::vector<float> operator*(float const scalar, std::vector<T> const &A) {
+    // Number of rows in A
+    size_t N_A = A.size();
+
+    std::vector<float> result(N_A);
+
+    for (size_t row = 0; row < N_A; row++) {
+        result[row] += A[row] * static_cast<float>(scalar);
+    }
+
+    return result;
+}
+
+/**
+ * post-multiplication of a vector by a scalar
+ * \returns resultant vector
+ */
+template <typename T>
+std::vector<float> operator*(std::vector<T> const &A, float const scalar) {
+    // Number of rows in A
+    size_t N_A = A.size();
+
+    std::vector<float> result(N_A);
+
+    for (size_t row = 0; row < N_A; row++) {
+        result[row] = A[row] * static_cast<float>(scalar);
+    }
+
+    return result;
+}
+
+/**
+ * division of a vector by a scalar
+ * \returns resultant vector
+ */
+template <typename T>
+std::vector<float> operator/(std::vector<T> const &A, float const scalar) {
+    return (1.f / scalar) * A;
+}
+
+/**
+ * subtraction of two vectors of identical lengths
+ * \returns resultant vector
+ */
+template <typename T>
+std::vector<T> operator-(std::vector<T> const &A, std::vector<T> const &B) {
+    // Number of rows in A
+    size_t N = A.size();
+
+    std::vector<T> result(N);
+
+    if (B.size() != N) {
+        std::cerr << "Vector dimensions shouldbe identical!" << std::endl;
+        return A;
+    }
+
+    for (size_t row = 0; row < N; row++) result[row] = A[row] - B[row];
+
+    return result;
+}
+
+/**
+ * addition of two vectors of identical lengths
+ * \returns resultant vector
+ */
+template <typename T>
+std::vector<T> operator+(std::vector<T> const &A, std::vector<T> const &B) {
+    // Number of rows in A
+    size_t N = A.size();
+
+    std::vector<T> result(N);
+
+    if (B.size() != N) {
+        std::cerr << "Vector dimensions shouldbe identical!" << std::endl;
+        return A;
+    }
+
+    for (size_t row = 0; row < N; row++) result[row] = A[row] + B[row];
+
+    return result;
+}
+
+/**
+ * Get matrix inverse using Row-trasnformations. Given matrix must
+ * be a square and non-singular.
+ * \returns inverse matrix
+ **/
+template <typename T>
+std::vector<std::vector<float>> get_inverse(
+    std::vector<std::vector<T>> const &A) {
+    // Assuming A is square matrix
+    size_t N = A.size();
+
+    std::vector<std::vector<float>> inverse(N);
+    for (size_t row = 0; row < N; row++) {
+        // preallocatae a resultant identity matrix
+        inverse[row] = std::vector<float>(N);
+        for (size_t col = 0; col < N; col++) {
+            inverse[row][col] = (row == col) ? 1.f : 0.f;
+        }
+    }
+
+    if (!is_square(A)) {
+        std::cerr << "A must be a square matrix!" << std::endl;
+        return inverse;
+    }
+
+    // preallocatae a temporary matrix identical to A
+    std::vector<std::vector<float>> temp(N);
+    for (size_t row = 0; row < N; row++) {
+        std::vector<float> v(N);
+        for (size_t col = 0; col < N; col++) {
+            v[col] = static_cast<float>(A[row][col]);
+        }
+        temp[row] = v;
+    }
+
+    // start transformations
+    for (size_t row = 0; row < N; row++) {
+        for (size_t row2 = row; row2 < N && temp[row][row] == 0; row2++) {
+            // this to ensure diagonal elements are not 0
+            temp[row] = temp[row] + temp[row2];
+            inverse[row] = inverse[row] + inverse[row2];
+        }
+
+        for (size_t col2 = row; col2 < N && temp[row][row] == 0; col2++) {
+            // this to further ensure diagonal elements are not 0
+            for (size_t row2 = 0; row2 < N; row2++) {
+                temp[row2][row] = temp[row2][row] + temp[row2][col2];
+                inverse[row2][row] = inverse[row2][row] + inverse[row2][col2];
+            }
+        }
+
+        if (temp[row][row] == 0) {
+            // Probably a low-rank matrix and hence singular
+            std::cerr << "Low-rank matrix, no inverse!" << std::endl;
+            return inverse;
+        }
+
+        // set diagonal to 1
+        auto divisor = static_cast<float>(temp[row][row]);
+        temp[row] = temp[row] / divisor;
+        inverse[row] = inverse[row] / divisor;
+        // Row transformations
+        for (size_t row2 = 0; row2 < N; row2++) {
+            if (row2 == row) {
+                continue;
+            }
+            float factor = temp[row2][row];
+            temp[row2] = temp[row2] - factor * temp[row];
+            inverse[row2] = inverse[row2] - factor * inverse[row];
+        }
+    }
+
+    return inverse;
+}
+
+/**
+ * matrix transpose
+ * \returns resultant matrix
+ **/
+template <typename T>
+std::vector<std::vector<T>> get_transpose(
+    std::vector<std::vector<T>> const &A) {
+    std::vector<std::vector<T>> result(A[0].size());
+
+    for (size_t row = 0; row < A[0].size(); row++) {
+        std::vector<T> v(A.size());
+        for (size_t col = 0; col < A.size(); col++) v[col] = A[col][row];
+
+        result[row] = v;
+    }
+    return result;
+}
+
+/**
+ * Perform Ordinary Least Squares curve fit. This operation is defined as
+ * \f[\beta = \left(X^TXX^T\right)Y\f]
+ * \param X feature matrix with rows representing sample vector of features
+ * \param Y known regression value for each sample
+ * \returns fitted regression model polynomial coefficients
+ */
+template <typename T>
+std::vector<float> fit_OLS_regressor(std::vector<std::vector<T>> const &X,
+                                     std::vector<T> const &Y) {
+    // NxF
+    std::vector<std::vector<T>> X2 = X;
+    for (size_t i = 0; i < X2.size(); i++) {
+        // add Y-intercept -> Nx(F+1)
+        X2[i].push_back(1);
+    }
+    // (F+1)xN
+    std::vector<std::vector<T>> Xt = get_transpose(X2);
+    // (F+1)x(F+1)
+    std::vector<std::vector<T>> tmp = get_inverse(Xt * X2);
+    // (F+1)xN
+    std::vector<std::vector<float>> out = tmp * Xt;
+    // cout << endl
+    //      << "Projection matrix: " << X2 * out << endl;
+
+    // Fx1,1    -> (F+1)^th element is the independent constant
+    return out * Y;
+}
+
+/**
+ * Given data and OLS model coeffficients, predict
+ * regression estimates. This operation is defined as
+ * \f[y_{\text{row}=i} = \sum_{j=\text{columns}}\beta_j\cdot X_{i,j}\f]
+ *
+ * \param X feature matrix with rows representing sample vector of features
+ * \param beta fitted regression model
+ * \return vector with regression values for each sample
+ **/
+template <typename T>
+std::vector<float> predict_OLS_regressor(std::vector<std::vector<T>> const &X,
+                                         std::vector<float> const &beta /**< */
+) {
+    std::vector<float> result(X.size());
+
+    for (size_t rows = 0; rows < X.size(); rows++) {
+        // -> start with constant term
+        result[rows] = beta[X[0].size()];
+        for (size_t cols = 0; cols < X[0].size(); cols++) {
+            result[rows] += beta[cols] * X[rows][cols];
+        }
+    }
+    // Nx1
+    return result;
+}
+
+/** Self test checks */
+void ols_test() {
+    /* test function = x^2 -5 */
+    std::cout << "Test 1 (quadratic function)....";
+    // create training data set with features = x, x^2, x^3
+    std::vector<std::vector<float>> data1(
+        {{-5, 25, -125}, {-1, 1, -1}, {0, 0, 0}, {1, 1, 1}, {6, 36, 216}});
+    // create corresponding outputs
+    std::vector<float> Y1({20, -4, -5, -4, 31});
+    // perform regression modelling
+    std::vector<float> beta1 = fit_OLS_regressor(data1, Y1);
+    // create test data set with same features = x, x^2, x^3
+    std::vector<std::vector<float>> test_data1(
+        {{-2, 4, -8}, {2, 4, 8}, {-10, 100, -1000}, {10, 100, 1000}});
+    // expected regression outputs
+    std::vector<float> expected1({-1, -1, 95, 95});
+    // predicted regression outputs
+    std::vector<float> out1 = predict_OLS_regressor(test_data1, beta1);
+    // compare predicted results are within +-0.01 limit of expected
+    for (size_t rows = 0; rows < out1.size(); rows++) {
+        assert(std::abs(out1[rows] - expected1[rows]) < 0.01);
+    }
+    std::cout << "passed\n";
+
+    /* test function = x^3 + x^2 - 100 */
+    std::cout << "Test 2 (cubic function)....";
+    // create training data set with features = x, x^2, x^3
+    std::vector<std::vector<float>> data2(
+        {{-5, 25, -125}, {-1, 1, -1}, {0, 0, 0}, {1, 1, 1}, {6, 36, 216}});
+    // create corresponding outputs
+    std::vector<float> Y2({-200, -100, -100, 98, 152});
+    // perform regression modelling
+    std::vector<float> beta2 = fit_OLS_regressor(data2, Y2);
+    // create test data set with same features = x, x^2, x^3
+    std::vector<std::vector<float>> test_data2(
+        {{-2, 4, -8}, {2, 4, 8}, {-10, 100, -1000}, {10, 100, 1000}});
+    // expected regression outputs
+    std::vector<float> expected2({-104, -88, -1000, 1000});
+    // predicted regression outputs
+    std::vector<float> out2 = predict_OLS_regressor(test_data2, beta2);
+    // compare predicted results are within +-0.01 limit of expected
+    for (size_t rows = 0; rows < out2.size(); rows++) {
+        assert(std::abs(out2[rows] - expected2[rows]) < 0.01);
+    }
+    std::cout << "passed\n";
+
+    std::cout << std::endl;  // ensure test results are displayed on screen
+                             // (flush stdout)
+}
+
+/**
+ * main function
+ */
+int main() {
+    ols_test();
+
+    size_t N = 0, F = 0;
+
+    std::cout << "Enter number of features: ";
+    // number of features = columns
+    std::cin >> F;
+    std::cout << "Enter number of samples: ";
+    // number of samples = rows
+    std::cin >> N;
+
+    std::vector<std::vector<float>> data(N);
+    std::vector<float> Y(N);
+
+    std::cout
+        << "Enter training data. Per sample, provide features and one output."
+        << std::endl;
+
+    for (size_t rows = 0; rows < N; rows++) {
+        std::vector<float> v(F);
+        std::cout << "Sample# " << rows + 1 << ": ";
+        for (size_t cols = 0; cols < F; cols++) {
+            // get the F features
+            std::cin >> v[cols];
+        }
+        data[rows] = v;
+        // get the corresponding output
+        std::cin >> Y[rows];
+    }
+
+    std::vector<float> beta = fit_OLS_regressor(data, Y);
+    std::cout << std::endl << std::endl << "beta:" << beta << std::endl;
+
+    size_t T = 0;
+    std::cout << "Enter number of test samples: ";
+    // number of test sample inputs
+    std::cin >> T;
+    std::vector<std::vector<float>> data2(T);
+    // vector<float> Y2(T);
+
+    for (size_t rows = 0; rows < T; rows++) {
+        std::cout << "Sample# " << rows + 1 << ": ";
+        std::vector<float> v(F);
+        for (size_t cols = 0; cols < F; cols++) std::cin >> v[cols];
+        data2[rows] = v;
+    }
+
+    std::vector<float> out = predict_OLS_regressor(data2, beta);
+    for (size_t rows = 0; rows < T; rows++) std::cout << out[rows] << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
39 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.